### PR TITLE
ci(repo): split gh-pages into build (PR) + deploy (main only)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,18 @@
 name: github pages
 
+# Two jobs:
+#
+# 1. `build` runs on every PR and on push to main. It compiles the
+#    book to catch syntax errors, broken links, and missing chapters
+#    early. No secrets required, so this works for PRs from forks.
+#
+# 2. `deploy` runs only on push to main and depends on `build`. It
+#    publishes the rendered book to felipebalbi/felipebalbi.github.io
+#    using the GH_PAGES_TOKEN repository secret. Secrets are NOT
+#    available to pull_request-triggered runs, which is why an earlier
+#    single-job design failed with "not found deploy key or tokens" on
+#    every PR.
+
 on:
   push:
     branches:
@@ -7,10 +20,8 @@ on:
   pull_request:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v6
 
@@ -20,10 +31,32 @@ jobs:
         uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: '0.5.2'
-          # mdbook-version: 'latest'
 
       - name: Build book
         run: mdbook build book
+
+      - name: Upload built book
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: book
+          path: ./book/book
+          retention-days: 1
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-deploy
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download built book
+        uses: actions/download-artifact@v4
+        with:
+          name: book
+          path: ./book/book
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary

Every PR run of the `github pages` workflow has been failing with:

```
##[error]Action failed with "not found deploy key or tokens"
```

Recent failed runs: [26969444040](https://github.com/OpenDevicePartnership/pico-de-gallo/actions/runs/26969444040), [26968740812](https://github.com/OpenDevicePartnership/pico-de-gallo/actions/runs/26968740812) (both on PR #58), [26926268899](https://github.com/OpenDevicePartnership/pico-de-gallo/actions/runs/26926268899) (PR #57). Only push-to-main runs succeed.

**Root cause:** the single `deploy` job tries to publish to `felipebalbi/felipebalbi.github.io` using `secrets.GH_PAGES_TOKEN`, but GitHub does not expose repository secrets to workflows triggered by `pull_request` from forks (including same-collaborator forks under the default repo settings). The token evaluates to empty string, `peaceiris/actions-gh-pages` aborts with the cryptic "not found deploy key or tokens" error. See [GitHub Actions security model docs](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets).

**The secret itself is fine.** The push-to-main runs succeed (e.g. [26968927499](https://github.com/OpenDevicePartnership/pico-de-gallo/actions/runs/26968927499) for PR #57's merge), proving `GH_PAGES_TOKEN` works when accessible. No rotation needed.

## Fix

Split the workflow into two jobs:

- **`build`** runs on every PR and on push to main. Compiles the book to catch syntax errors, broken links, and missing chapters early. No secrets required, so PRs from forks pass cleanly. Uploads the rendered book as an artifact when triggered by push-to-main so the deploy job doesn't have to rebuild.
- **`deploy`** runs only on push to main and depends on `build`. Downloads the artifact and publishes to the external pages repo using `GH_PAGES_TOKEN`.

No change to the actions used (`peaceiris/actions-mdbook@v2`, `peaceiris/actions-gh-pages@v4`). No change to the `GH_PAGES_TOKEN` secret. No change to the publish destination.

**Side benefit:** PRs that break mdbook (missing chapters, broken cross-references, malformed front-matter) now surface as a real CI failure instead of being masked by the "deploy fails for unrelated reasons" failure that has been hiding all book-syntax bugs.

## Test plan

- [x] `mdbook build book` clean locally
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] LF line endings
- [ ] CI on this PR runs the new `build` job and passes (will verify after PR opens)
- [ ] After merge, CI on `main` runs `build` then `deploy` and publishes the book (will verify on next push to main)

## Diff

One file changed (`.github/workflows/gh-pages.yml`), +37/-4.
