### PR TITLE
chore(repo): Bump spin off yanked 0.9.8 to 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,9 +1434,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/crates/pico-de-gallo-firmware/Cargo.lock
+++ b/crates/pico-de-gallo-firmware/Cargo.lock
@@ -1430,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
## Summary

The `check` workflow's `cargo-deny (.)` job was failing the **advisories** check because `spin 0.9.8` was **yanked** from crates.io:

```
error[yanked]: detected yanked crate (try `cargo update -p spin`)
   spin v0.9.8  ←  heapless 0.7.17  ←  postcard 1.1.3
advisories FAILED, bans ok, licenses ok, sources ok
```

`deny.toml` sets `yanked = "deny"`, so the yanked crate hard-failed the job and gated the whole workflow. All other jobs (fmt, clippy, doc, hack, test, msrv, lockfile, actionlint, semver) were green.

## Fix

`cargo update -p spin` in **both** workspaces (host root + firmware), bumping `spin 0.9.8 → 0.9.9`. This is a semver-compatible, **lockfile-only** change — no `Cargo.toml` edits, so both lockfiles stay in sync with their manifests (the `lockfile` job is unaffected).

## Verification

- `cargo check --locked` — passes in the host workspace and firmware (`thumbv8m.main-none-eabihf`).
- `cargo-deny` (0.20.2, exact CI command) — `advisories ok, bans ok, licenses ok, sources ok` in **both** workspaces.

## Notes

The `advisory-not-detected` warnings that also appear in the cargo-deny output are **not** stale ignores — they are an inherent artifact of one shared `deny.toml` being evaluated against two workspaces that each contain only a subset of the ignored crates (each ignore entry is live in at least one workspace). They are warnings and do not fail CI; intentionally left untouched.